### PR TITLE
Handle missing graph id

### DIFF
--- a/samples/basic1.dot
+++ b/samples/basic1.dot
@@ -1,4 +1,4 @@
-digraph D {
+digraph {
   A [shape=diamond]
   B [shape=box]
   C [shape=circle]

--- a/samples/reference/basic1.ref
+++ b/samples/reference/basic1.ref
@@ -1,5 +1,5 @@
 Graph {
-    id: "D",
+    id: "",
     is_strict: false,
     statements: [
         Node(


### PR DESCRIPTION
At some point (or maybe always, who knows?) `digraph` started to accept syntax there the [graph name is optional](https://graphviz.org/doc/info/lang.html).

This change permits the lack of the id. In this case it is interpreted to be empty.

I also don't know what the `todo!()` was about, but it seems returning a descriptive error in that case would be more appropriate than crashing.

E.g. `cargo-modules` produces these kind of graphs.